### PR TITLE
E-feat:member account page layout

### DIFF
--- a/pages/templates/pages/member.html
+++ b/pages/templates/pages/member.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MOOEDULE 多揪</title>
+    <!-- 引入 Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- 引入 Flaticon 圖示庫 -->
+    <link
+      rel="stylesheet"
+      href="https://cdn-uicons.flaticon.com/2.6.0/uicons-regular-rounded/css/uicons-regular-rounded.css"
+    />
+  </head>
+  <body class="bg-gray-100">
+    <!-- Header Navigation -->
+    <header class="bg-white p-5 flex justify-between items-center shadow-md">
+      <!-- Logo -->
+      <div class="text-2xl font-bold flex items-center">
+        <img src="logo.png" alt="MOORDULE Logo" class="w-8 h-8 mr-2" />
+        <span>MOORDULE 多揪</span>
+      </div>
+
+      <!-- 搜尋框與按鈕 -->
+      <div class="flex items-center space-x-4 ml-auto">
+        <div class="relative">
+          <!-- 搜尋圖示 -->
+          <i class="fi fi-rr-search absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
+          <!-- 搜尋框 -->
+          <input
+            type="text"
+            placeholder="我想要揪..."
+            class="border border-gray-300 pr-10 pl-4 py-2 rounded-full focus:outline-none focus:ring-2 focus:ring-yellow-500 text-gray-500 w-60"
+          />
+        </div>
+
+        <!-- 活動按鈕 -->
+        <button class="bg-[#F78888] text-white rounded-[50px] px-[20px] py-[10px]">
+          活動
+        </button>
+        <!-- 登出按鈕 -->
+        <button class="bg-[#5DA2D5] text-white rounded-[50px] px-[20px] py-[10px]">
+          登出
+        </button>
+      </div>
+    </header>
+
+    <!-- Navigation Bar -->
+    <nav class="space-x-5 flex justify-center items-center mt-5 mx-auto w-max">
+      <a href="#" class="text-yellow-500">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-400 text-xl">
+          我的頁面
+        </button>
+      </a>
+      <a href="#">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+          我的帳號
+        </button>
+      </a>
+      <a href="#">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+          我的活動
+        </button>
+      </a>
+      <a href="#">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+          我的收藏
+        </button>
+      </a>
+      <a href="#">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+          我的紀錄
+        </button>
+      </a>
+      <a href="#">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+          創建活動
+        </button>
+      </a>
+      <a href="#">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+          聊天室
+        </button>
+      </a>
+      <a href="#">
+        <div class="flex items-center space-x-2">
+          <!-- 系統通知 -->
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            系統通知
+          </button>
+          <!-- 獨立的 X 按鈕 -->
+          <button
+            class="w-10 h-10 text-white hover:bg-yellow-500 focus:outline-none border bg-yellow-500 rounded-full flex items-center justify-center"
+            onclick="document.getElementById('notification-bar').style.display='none';"
+          >
+            <i class="fi fi-rr-cross"></i>
+          </button>
+        </div>
+      </a>
+    </nav>
+
+    <!-- Main Container -->
+    <div id="notification-bar" class="bg-yellow-300 p-6 rounded-[30px] max-w-screen-lg mx-auto mt-6">
+      <div class="grid grid-cols-3 gap-4">
+        <!-- 用戶資訊卡 -->
+        <div class="bg-white p-4 rounded-lg shadow-lg">
+          <div class="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center">
+            <span class="text-gray-500">用戶 photo</span>
+          </div>
+          <div class="w-full h-48 bg-gray-200 rounded-lg flex flex-col items-center justify-center mt-4">
+            <h3 class="text-gray-700 font-semibold">— 顯示名稱 —</h3>
+            <p class="text-gray-500">興趣 #</p>
+          </div>
+        </div>
+
+        <!-- 活動資訊卡 -->
+        <div class="bg-white p-4 rounded-lg shadow-lg">
+          <div class="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center">
+            <span class="text-gray-500">活動 photo</span>
+          </div>
+          <div class="w-full h-48 bg-gray-200 rounded-lg flex flex-col items-center justify-center mt-4">
+            <p class="text-gray-700 font-semibold">聚會名稱：</p>
+            <p class="text-yellow-500">跟首頁活動卡牌一致</p>
+          </div>
+        </div>
+
+        <!-- 我的錢包 -->
+        <div class="bg-white p-4 rounded-lg shadow-lg text-center">
+          <h3 class="text-gray-700 mb-2">我的錢包</h3>
+          <div class="w-32 h-24 mx-auto bg-yellow-400 rounded-full flex items-center justify-center text-white text-7xl font-small">
+            99
+          </div>
+          <button class="mt-4 bg-yellow-400 text-white px-8 py-2 rounded-full">
+            儲值
+          </button>
+        </div>
+
+        <!-- 日曆卡 -->
+        <div class="bg-white p-4 rounded-lg shadow-lg text-center col-span-1">
+          <h3 class="text-yellow-500 font-bold">日曆</h3>
+          <p class="text-yellow-500">可以連 google</p>
+        </div>
+
+        <!-- 最新消息卡 -->
+        <div class="bg-white p-4 rounded-lg shadow-lg col-span-2">
+          <h3 class="text-gray-700 mb-4">最新消息</h3>
+          <div class="h-12 bg-gray-200 rounded mb-2"></div>
+          <div class="h-12 bg-gray-200 rounded mb-2"></div>
+          <div class="h-12 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/pages/templates/pages/member.html
+++ b/pages/templates/pages/member.html
@@ -1,9 +1,6 @@
-<!DOCTYPE html>
-<html lang="zh-Hant">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MOOEDULE 多揪</title>
+{%extend "base/layout.html"%}
+
+{%block head%}
     <!-- 引入 Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- 引入 Flaticon 圖示庫 -->
@@ -11,8 +8,11 @@
       rel="stylesheet"
       href="https://cdn-uicons.flaticon.com/2.6.0/uicons-regular-rounded/css/uicons-regular-rounded.css"
     />
-  </head>
-  <body class="bg-gray-100">
+{%enblcok head%}
+
+{%block content%}
+
+  <div class="bg-gray-100">
     <!-- Header Navigation -->
     <header class="bg-white p-5 flex justify-between items-center shadow-md">
       <!-- Logo -->
@@ -115,6 +115,7 @@
 
         <!-- 活動資訊卡 -->
         <div class="bg-white p-4 rounded-lg shadow-lg">
+          <p class="text-gray-500 font-medium text-2xl text-center">已報名的活動</p>
           <div class="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center">
             <span class="text-gray-500">活動 photo</span>
           </div>
@@ -126,11 +127,11 @@
 
         <!-- 我的錢包 -->
         <div class="bg-white p-4 rounded-lg shadow-lg text-center">
-          <h3 class="text-gray-700 mb-2">我的錢包</h3>
+          <h3 class="text-gray-700 mb-2 text-xl">我的錢包</h3>
           <div class="w-32 h-24 mx-auto bg-yellow-400 rounded-full flex items-center justify-center text-white text-7xl font-small">
             99
           </div>
-          <button class="mt-4 bg-yellow-400 text-white px-8 py-2 rounded-full">
+          <button class="mt-4 bg-yellow-400 text-white text-xl px-8 py-2 rounded-full">
             儲值
           </button>
         </div>
@@ -150,5 +151,6 @@
         </div>
       </div>
     </div>
-  </body>
-</html>
+  </div>
+
+  {%enbock content%}


### PR DESCRIPTION
#53
member account page layout
新增：

- [ ]  logo 位置、搜尋欄
- [ ] 活動、登出按鈕
- [ ]  我的頁面、我的帳號、我的活動、我的收藏、我的紀錄、創建活動、聊天室、系統通知、X鍵按鈕
- [ ] 用戶photo、活動photo、我的錢包、日曆、最新消息欄位

[
<img width="1273" alt="截圖 2024-12-18 下午2 33 22" src="https://github.com/user-attachments/assets/f61907bb-fe88-4768-93fe-377f07e0e9fa" />
](url)