### PR TITLE
R-feat:auth_components(email_input, password_input) 的定義

### DIFF
--- a/activities/models.py
+++ b/activities/models.py
@@ -4,27 +4,47 @@ from django.utils import timezone
 
 
 class Activity(models.Model):
+    # """
+    # Activity
+    # 欄位說明：
+    # - title: 活動名稱或主題。
+    # - description: 活動描述。
+    # - location_area: 活動所在區域(如台北市信義區)
+    # - start_time, end_time: 活動開始與結束時間。
+    # - max_participants: 活動限制的人數上限。
+    # - creator: 活動創建者(透過外部User或Member模型)。
+    # - created_at: 活動建立時間。
+
+    # 後續擴充可以新增：
+    # - tags、image、budget_type、event_type等欄位。
+    # - 參加者中介模型(Participation)、留言模型(Comment)、回饋模型(Feedback)。
+    # - 金流相關(Wallet等)。
+    # """
 
     title = models.CharField(max_length=100, help_text="活動標題")
     description = models.TextField(help_text="活動描述", blank=True)
-    address = models.CharField(max_length=255, help_text="活動地址，例：台北市信義區市府路1號")
+    address = models.CharField(
+        max_length=255, help_text="活動地址，例：台北市信義區市府路1號"
+    )
     start_time = models.DateTimeField(help_text="活動開始時間")
-    end_time = models.DateTimeField(null=True, blank=True, help_text="活動結束時間(選填)")
+    end_time = models.DateTimeField(
+        null=True, blank=True, help_text="活動結束時間(選填)"
+    )
     max_participants = models.PositiveIntegerField(help_text="參加人數上限", default=10)
-    
-     # 此處的creator為簡化，未來整合會員系統時，把 AUTH_USER_MODEL 改成實際的會員模型
+
+    # 此處的creator為簡化，未來整合會員系統時，把 AUTH_USER_MODEL 改成實際的會員模型
     # 目前先使用 settings.AUTH_USER_MODEL
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
-        related_name='created_activities',
-        help_text="活動創辦人"
+        related_name="created_activities",
+        help_text="活動創辦人",
     )
     created_at = models.DateTimeField(auto_now_add=True, help_text="活動建立時間")
 
     def __str__(self):
         return f"{self.title} ({self.start_time.strftime('%Y-%m-%d %H:%M')})"
-    
+
     @property
     def is_upcoming(self):
         return self.start_time > timezone.now()

--- a/pydev/settings.py
+++ b/pydev/settings.py
@@ -93,13 +93,8 @@ DATABASES = {
         "NAME": os.getenv("POSTGRES_DB"),
         "USER": os.getenv("POSTGRES_USER"),
         "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
-        "HOST": os.getenv("POSTGRES_HOST", "localhost"),
-        "PORT": os.getenv("POSTGRES_PORT", "5433"),
-        "NAME": os.getenv("POSTGRES_DB"),
-        "USER": os.getenv("POSTGRES_USER"),
-        "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
         "HOST": os.getenv("POSTGRES_HOST"),
-        "PORT": os.getenv("POSTGRES_PORT", "5433"),
+        "PORT": os.getenv("POSTGRES_PORT"),
     }
 }
 

--- a/users/templatetags/auth_components.py
+++ b/users/templatetags/auth_components.py
@@ -1,0 +1,28 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag("users/components/email_input.html")
+def email_input(verbose_name="", value="", error="", placeholder="", validate=True):
+    return {
+        "verbose_name": verbose_name,
+        "value": value,
+        "error": error,
+        "placeholder": placeholder,
+        "should_validate": validate,
+    }
+
+
+@register.inclusion_tag("users/components/password_input.html")
+def password_input(
+    verbose_name="", name="", value="", error="", placeholder="", validate=True
+):
+    return {
+        "verbose_name": verbose_name,
+        "name": name,
+        "value": value,
+        "error": error,
+        "placeholder": placeholder,
+        "should_validate": validate,
+    }


### PR DESCRIPTION
### 新增認證相關的模板標籤

新增兩個模板標籤來標準化認證表單：

1. `email_input` 電子郵件輸入組件：
   - 標準化電子郵件輸入欄位
   - 可自訂標籤和提示文字
   - 支援與 Django Form 整合

2. `password_input` 密碼輸入組件：
   - 產生密碼輸入欄位
   - 可自訂驗證選項
   - 支援密碼確認欄位

使用範例：
```django
{% load auth_components %}

{# 電子郵件輸入 #}
{% email_input 
    verbose_name="電子郵件："
    name="email"
    placeholder="請輸入電子郵件"
%}

{# 密碼輸入 #}
{% password_input 
    verbose_name="密碼："
    name="password"
    placeholder="請輸入密碼"
    validate=True
%}