### PR TITLE
E-feat: member data layout page

### DIFF
--- a/pages/templates/pages/account.html
+++ b/pages/templates/pages/account.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 {% extends "base/layout.html" %}
 {% load static %}
 
@@ -49,12 +50,12 @@
     <!-- Navigation Bar -->
     <nav class="space-x-5 flex justify-center items-center mt-5 mx-auto w-max">
       <a href="#" class="text-yellow-500">
-        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-400 text-xl">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
           我的頁面
         </button>
       </a>
       <a href="#">
-        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+        <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-400 text-xl">
           我的帳號
         </button>
       </a>
@@ -94,63 +95,50 @@
             class="w-10 h-10 text-white hover:bg-yellow-500 focus:outline-none border bg-yellow-500 rounded-full flex items-center justify-center"
             onclick="document.getElementById('notification-bar').style.display='none';"
           >
+            <i class="fi fi-rr-cross"></i>
           </button>
         </div>
       </a>
     </nav>
 
+
     <!-- Main Container -->
-    <div id="notification-bar" class="bg-yellow-300 p-6 rounded-[24px] max-w-screen-lg mx-auto mt-6">
-      <div class="grid grid-cols-3 gap-4">
-        <!-- 用戶資訊卡 -->
-        <div class="bg-white p-4 rounded-lg shadow-lg">
-          <div class="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center">
-            <span class="text-gray-500">用戶 photo</span>
-          </div>
-          <div class="w-full h-48 bg-gray-200 rounded-lg flex flex-col items-center justify-center mt-4">
-            <h3 class="text-gray-700 font-semibold">— 顯示名稱 —</h3>
-            <p class="text-gray-500">興趣 #</p>
-          </div>
+    <main class="max-w-screen-lg mx-auto mt-6 p-[30px] bg-yellow-300 rounded-[24px] p-6 grid grid-cols-3 gap-4">
+      <!-- 左側：用戶資訊 -->
+      <div class="bg-white rounded-lg shadow-lg p-4 flex flex-col items-center">
+        <div class="w-48 h-48 bg-gray-300 rounded-lg flex items-center justify-center">
+          <span class="text-gray-500">顯示用戶上傳的 photo</span>
         </div>
-
-        <!-- 活動資訊卡 -->
-        <div class="bg-white p-4 rounded-lg shadow-lg">
-          <p class="text-gray-500 font-medium text-2xl text-center">已報名的活動</p>
-          <div class="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center">
-            <span class="text-gray-500">活動 photo</span>
-          </div>
-          <div class="w-full h-48 bg-gray-200 rounded-lg flex flex-col items-center justify-center mt-4">
-            <p class="text-gray-700 font-semibold">聚會名稱：</p>
-            <p class="text-yellow-500">跟首頁活動卡牌一致</p>
-          </div>
-        </div>
-
-        <!-- 我的錢包 -->
-        <div class="bg-white p-4 rounded-lg shadow-lg text-center">
-          <h3 class="text-gray-700 mb-2 text-xl">我的錢包</h3>
-          <div class="w-32 h-24 mx-auto bg-yellow-400 rounded-full flex items-center justify-center text-white text-7xl font-small">
-            99
-          </div>
-          <button class="mt-4 bg-yellow-400 text-white text-xl px-8 py-2 rounded-full">
-            儲值
-          </button>
-        </div>
-
-        <!-- 日曆卡 -->
-        <div class="bg-white p-4 rounded-lg shadow-lg text-center col-span-1">
-          <h3 class="text-yellow-500 font-bold">日曆</h3>
-          <p class="text-yellow-500">可以連 google</p>
-        </div>
-
-        <!-- 最新消息卡 -->
-        <div class="bg-white p-4 rounded-lg shadow-lg col-span-2">
-          <h3 class="text-gray-700 mb-4">最新消息</h3>
-          <div class="h-12 bg-gray-200 rounded mb-2"></div>
-          <div class="h-12 bg-gray-200 rounded mb-2"></div>
-          <div class="h-12 bg-gray-200 rounded"></div>
-        </div>
+        <h3 class="text-gray-700 font-bold mt-4">顯示名稱</h3>
+        <button class="mt-4 bg-yellow-400 text-white px-4 py-2 rounded-full hover:bg-yellow-500">編輯</button>
       </div>
-    </div>
-  </div>
 
+      <!-- 中間：個人資料 -->
+      <div class="bg-white rounded-lg shadow-lg p-4">
+        <h3 class="text-yellow-500 font-bold">個人資料</h3>
+        <p class="mt-2 text-gray-700">姓名：<span class="text-gray-500">用戶姓名</span></p>
+        <p class="mt-2 text-gray-700">性別：<span class="text-gray-500">用戶性別</span></p>
+        <p class="mt-2 text-gray-700">生日：<span class="text-gray-500">用戶生日</span></p>
+        <p class="mt-2 text-gray-700">所在地區：<span class="text-gray-500">用戶地區</span></p>
+        <button class="mt-4 bg-yellow-400 text-white px-4 py-2 rounded-full hover:bg-yellow-500">編輯</button>
+      </div>
+
+      <!-- 右側：帳號資料 -->
+      <div class="bg-white rounded-lg shadow-lg p-4">
+        <h3 class="text-yellow-500 font-bold">帳號資料</h3>
+        <p class="mt-2 text-gray-700">帳號：<span class="text-gray-500">用戶帳號</span></p>
+        <p class="mt-2 text-gray-700">密碼：<span class="text-gray-500">********</span></p>
+        <p class="mt-2 text-gray-700">雙重驗證：<span class="text-gray-500">已啟用</span></p>
+        <button class="mt-4 bg-yellow-400 text-white px-4 py-2 rounded-full hover:bg-yellow-500">變更密碼</button>
+        <button class="mt-4 bg-yellow-400 text-white px-4 py-2 rounded-full hover:bg-yellow-500">雙重驗證</button>
+      </div>
+
+      <!-- 下方：關於我 -->
+      <div class="col-span-3 bg-white rounded-lg shadow-lg p-4">
+        <h3 class="text-yellow-500 font-bold">關於我</h3>
+        <p class="mt-2 text-gray-700">用戶輸入自我介紹 {% lorem 1 b random %}</p>
+        <button class="mt-4 bg-yellow-400 text-white px-4 py-2 rounded-full hover:bg-yellow-500">編輯</button>
+      </div>
+    </main>
+  </body>
   {%endblock content%}

--- a/pages/templates/pages/event.html
+++ b/pages/templates/pages/event.html
@@ -1,0 +1,155 @@
+{% extends "base/layout.html" %}
+{% load static %}
+
+{%block head%}
+    <!-- 引入 Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- 引入 Flaticon 圖示庫 -->
+    <link
+      rel="stylesheet"
+      href="https://cdn-uicons.flaticon.com/2.6.0/uicons-regular-rounded/css/uicons-regular-rounded.css"
+    />
+{%endblock head%}
+
+{%block content%}
+
+  <div class="bg-gray-100">
+    <!-- Header Navigation -->
+    <header class="bg-white p-5 flex justify-between items-center shadow-md">
+      <!-- Logo -->
+      <div class="text-2xl font-bold flex items-center">
+        <img src="{% static 'logo.png' %}" alt="Logo" class="w-8 h-8 mr-2">
+        <span>MOORDULE 多揪</span>
+      </div>
+
+      <!-- 搜尋框與按鈕 -->
+      <div class="flex items-center space-x-4 ml-auto">
+        <div class="relative">
+          <!-- 搜尋圖示 -->
+          <i class="fi fi-rr-search absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
+          <!-- 搜尋框 -->
+          <input
+            type="text"
+            placeholder="我想要揪..."
+            class="border border-gray-300 pr-10 pl-4 py-2 rounded-full focus:outline-none focus:ring-2 focus:ring-yellow-500 text-gray-500 w-60"
+          />
+        </div>
+
+        <!-- 活動按鈕 -->
+        <button class="bg-[#F78888] text-white rounded-[50px] px-[20px] py-[10px]">
+          活動
+        </button>
+        <!-- 登出按鈕 -->
+        <button class="bg-[#5DA2D5] text-white rounded-[50px] px-[20px] py-[10px]">
+          登出
+        </button>
+      </div>
+    </header>
+
+    <!-- Navigation Bar -->
+    <nav class="space-x-5 flex justify-center items-center mt-5 mx-auto w-max">
+        <a href="#" class="text-yellow-500">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            我的頁面
+          </button>
+        </a>
+        <a href="#">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            我的帳號
+          </button>
+        </a>
+        <a href="#">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-400 text-xl">
+            我的活動
+          </button>
+        </a>
+        <a href="#">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            我的收藏
+          </button>
+        </a>
+        <a href="#">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            我的紀錄
+          </button>
+        </a>
+        <a href="#">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            創建活動
+          </button>
+        </a>
+        <a href="#">
+          <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+            聊天室
+          </button>
+        </a>
+        <a href="#">
+          <div class="flex items-center space-x-2">
+            <!-- 系統通知 -->
+            <button class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white bg-yellow-300 text-xl">
+              系統通知
+            </button>
+            <!-- 獨立的 X 按鈕 -->
+            <button
+              class="w-10 h-10 text-white hover:bg-yellow-500 focus:outline-none border bg-yellow-500 rounded-full flex items-center justify-center"
+              onclick="document.getElementById('notification-bar').style.display='none';"
+            >
+            </button>
+          </div>
+        </a>
+      </nav>
+  
+
+      <div class="bg-gray-100 py-8">
+        <!-- 外層容器，設置寬度 -->
+        <div class="max-w-screen-lg mx-auto px-4">
+            <!-- 卡片區域 -->
+            <div class="grid grid-cols-3 gap-6">
+                <!-- 卡片1 -->
+                <div class="bg-yellow-300 rounded-lg p-4">
+                    <p class="text-white font-bold text-center p-2">即將到來的活動</p>
+                    <div class="bg-gray-300 h-32 rounded-lg flex items-center justify-center text-gray-600"> 活動photo</div>
+                    <p class="text-center font-bold mt-4">顯示用戶參加的活動</p>
+                </div>
+    
+                <!-- 卡片2 -->
+                <div class="bg-yellow-300 rounded-lg p-4">
+                    <div class="bg-gray-300 h-32 rounded-lg flex items-center justify-center text-gray-600"> 活動photo</div>
+                    <p class="text-center font-bold mt-4">顯示用戶參加的活動</p>
+                </div>
+    
+                <!-- 卡片3 -->
+                <div class="bg-yellow-300 rounded-lg p-4">
+                    <div class="bg-gray-300 h-32 rounded-lg flex items-center justify-center text-gray-600"> 活動photo</div>
+                    <p class="text-center font-bold mt-4">顯示用戶參加的活動</p>ｃ
+                </div>
+    
+                <!-- 卡片4 -->
+                <div class="bg-yellow-300 rounded-lg p-4">
+                    <p class="text-yellow-600 font-bold">我的收藏</p>
+                    <div class="bg-gray-300 h-32 rounded-lg flex items-center justify-center text-gray-600">收藏的內容</div>
+                    <button class="bg-yellow-500 text-white rounded-full px-4 py-2 mt-4 mx-auto block">查看更多</button>
+                </div>
+    
+                <!-- 卡片5 -->
+                <div class="bg-yellow-300 rounded-lg p-4">
+                    <p class="text-yellow-600 font-bold">系統通知</p>
+                    <div class="bg-gray-300 h-32 rounded-lg flex items-center justify-center text-gray-600">通知訊息</div>
+                    <button class="bg-yellow-500 text-white rounded-full px-4 py-2 mt-4 mx-auto block">查看通知</button>
+                </div>
+    
+                <!-- 卡片6 -->
+                <div class="bg-yellow-300 rounded-lg p-4">
+                    <p class="text-yellow-600 font-bold">聊天訊息</p>
+                    <div class="bg-gray-300 h-32 rounded-lg flex items-center justify-center text-gray-600">聊天列表</div>
+                    <button class="bg-yellow-500 text-white rounded-full px-4 py-2 mt-4 mx-auto block">打開聊天</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    
+
+</body>
+{%endblock content%}
+


### PR DESCRIPTION
新增：

1. member data layout page
- [ ]  logo 位置、搜尋欄、活動、登出按鈕
- [ ]  我的頁面、我的帳號、我的活動、我的收藏、我的紀錄、創建活動、聊天室、系統通知、X鍵按鈕
- [ ] 顯示用戶上傳的 photo、個人資料、帳號資料、關於我

<img width="1271" alt="截圖 2024-12-20 中午12 51 09" src="https://github.com/user-attachments/assets/f3879c86-e293-4b77-86a4-52af7fef4803" />

2. membership event layout page

- [ ] logo 位置、搜尋欄、活動、登出按鈕
- [ ]  我的頁面、我的帳號、我的活動、我的收藏、我的紀錄、創建活動、聊天室、系統通知、X鍵按鈕
- [ ] 活動photo、顯示用戶參加的活動、我的收藏、系統通知、聊天訊息

<img width="1279" alt="截圖 2024-12-20 下午5 28 46" src="https://github.com/user-attachments/assets/32394a61-bf87-45c9-be42-35eb3670b5fe" />

