### PR TITLE
E-feat third party login

### DIFF
--- a/pages/views.py
+++ b/pages/views.py
@@ -3,5 +3,5 @@ from django.shortcuts import render
 # Create your views here.
 
 
-def index_view(request, *args, **kwargs):
-    return render(request, "pages/index.html")
+def index_view(request):
+    return render(request, "pages/event.html")

--- a/pydev/settings.py
+++ b/pydev/settings.py
@@ -9,26 +9,35 @@ https://docs.djangoproject.com/en/5.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
-
 import os
+import environ 
 from pathlib import Path
+from dotenv import load_dotenv
+load_dotenv()
 
 from dotenv import load_dotenv
 
 load_dotenv()
 AUTH_USER_MODEL = "users.CustomUser"
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
+DEBUG = os.getenv('DEBUG', 'True') == 'True'
+
+ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '*').split(',')
+
+# 初始化環境變數
 BASE_DIR = Path(__file__).resolve().parent.parent
+# env = environ.Env(DEBUG=(bool, False))
+# environ.Env.read_env(str(BASE_DIR / ".env"))
 db_url = os.getenv("DATABASE_URL")
 # AUTH_USER_MODEL = "users.CustomUser"
+# DEBUG = env.bool("DEBUG", default=False)
+
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("SECRET_KEY")
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
 
 ALLOWED_HOSTS = []
 
@@ -36,6 +45,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    # Django 內建 APP
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -47,7 +57,19 @@ INSTALLED_APPS = [
     "shared",
     "activities",
     "cashflows",
+    # 第三方套件
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',  # Google 登入提供者
 ]
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',  # Django 預設認證
+    'allauth.account.auth_backends.AuthenticationBackend',  # allauth 認證
+]
+
+SITE_ID = 1
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -57,7 +79,11 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware", # Add the account middleware:
 ]
+
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'
 
 ROOT_URLCONF = "pydev.urls"
 
@@ -83,8 +109,16 @@ TEMPLATES = [
 WSGI_APPLICATION = "pydev.wsgi.application"
 
 
-# Database
-# https://docs.djangoproject.com/en/5.1/ref/settings/#databases
+SOCIALACCOUNT_PROVIDERS = {
+    "google": {
+        "APP": {
+            "client_id": os.getenv("GMAIL_CLIENT_ID"),
+            "secret": os.getenv("GMAIL_API_SECRET"),
+        },
+        "SCOPE": ["profile", "email"],
+        "AUTH_PARAMS": {"access_type": "online"},
+    }
+}
 
 
 DATABASES = {
@@ -93,13 +127,8 @@ DATABASES = {
         "NAME": os.getenv("POSTGRES_DB"),
         "USER": os.getenv("POSTGRES_USER"),
         "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
-        "HOST": os.getenv("POSTGRES_HOST", "localhost"),
-        "PORT": os.getenv("POSTGRES_PORT", "5433"),
-        "NAME": os.getenv("POSTGRES_DB"),
-        "USER": os.getenv("POSTGRES_USER"),
-        "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
         "HOST": os.getenv("POSTGRES_HOST"),
-        "PORT": os.getenv("POSTGRES_PORT", "5433"),
+        "PORT": os.getenv("POSTGRES_PORT"),
     }
 }
 
@@ -125,7 +154,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
@@ -134,3 +164,5 @@ STATICFILES_DIRS = [
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+

--- a/pydev/urls.py
+++ b/pydev/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path("activities/", include("activities.urls")),
     path("cashflows/", include("cashflows.urls")),
     path("users/", include("users.urls")),
+    path('accounts/', include('allauth.urls')),  # allauth URL
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ python = "^3.12"
 django = "^5.1.4"
 psycopg2-binary = "^2.9.10"
 psycopg = {extras = ["binary"], version = "^3.2.3"}
+django-allauth = "^65.3.0"
+cryptography = "^44.0.0"
+pyjwt = "^2.10.1"
 python-dotenv = "^1.0.1"
 
 


### PR DESCRIPTION
#170 
Google第三方登入已設定API和金鑰，

待Users Model建立完畢，方能測試是否串接成功。#215
屆時會補上功能測試影片，目前先附上設定好的程式碼與說明。

- [ ] 設定settings:
```
#載入 .env 檔案中的環境變數，讓程式能夠以安全且動態的方式存取設定值
import environ 
from dotenv import load_dotenv
load_dotenv()

#從環境變數中取得 DEBUG 的值，預設為 'True'，將其轉換為布林值
DEBUG = os.getenv('DEBUG', 'True') == 'True'

#從環境變數中取得 ALLOWED_HOSTS 的值，若無則預設為 '*'，將其用逗號分隔轉換為列表
ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '*').split(',')

# 初始化環境變數
BASE_DIR = Path(__file__).resolve().parent.parent
db_url = os.getenv("DATABASE_URL")

INSTALLED_APPS = [
# 第三方套件
    'allauth',
    'allauth.account',
    'allauth.socialaccount',
    'allauth.socialaccount.providers.google',  # Google 登入提供者
]

- [ ] 

AUTHENTICATION_BACKENDS = [
    'django.contrib.auth.backends.ModelBackend',  # Django 預設認證
    'allauth.account.auth_backends.AuthenticationBackend',  # allauth 認證
]

#設定 SITE_ID 為 1，用 Django 的 sites 框架以指定當前站點的 ID
SITE_ID = 1

# 處理 Django Allauth 提供的帳戶相關中介層邏輯，如自動管理用戶會話和登入狀態
MIDDLEWARE = [
   "allauth.account.middleware.AccountMiddleware", 
]

#使用 Google 作為第三方登入提供者的相關參數
SOCIALACCOUNT_PROVIDERS = {
    "google": {
        "APP": {
            "client_id": os.getenv("GMAIL_CLIENT_ID"),
            "secret": os.getenv("GMAIL_API_SECRET"),
        },
        "SCOPE": ["profile", "email"],
        "AUTH_PARAMS": {"access_type": "online"},
    }
}
```

- [ ] 設定urls
```
urlpatterns = [
    path('accounts/', include('allauth.urls')),  # allauth URL
]
```