### PR TITLE
R-feat:新增 email 輸入組件和驗證功能

### DIFF
--- a/users/templates/users/components/email_input.html
+++ b/users/templates/users/components/email_input.html
@@ -1,0 +1,71 @@
+<div
+	x-data="{ 
+	value: '{{ value|default:''|escapejs }}', 
+	serverError: '{{ error|default:''|escapejs }}',
+	clientError: '', 
+	isValid: null,
+	validate() {
+		{% if should_validate %}
+			const regex = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+			this.isValid = regex.test(this.value);
+			this.clientError = this.isValid ? '' : 'username@domain.com';
+		{% else %}
+			this.isValid = true;
+			this.clientError = '';
+		{% endif %}
+	},
+	getError() {
+	  this.validate();
+		if (this.serverError) return this.serverError;  
+		return this.clientError;  
+	},
+	init() {
+		this.$watch('value', () => {
+			this.validate();
+			if (this.serverError) this.serverError = '';
+		});
+	}
+}"
+>
+	<div class="flex my-2 px-4 gap-2 items-center">
+		<label class="block text-gray-700 font-medium" for="email">
+			{% if verbose_name %}{{ verbose_name }}{% else %}Email{% endif %}
+		</label>
+		{% if error or should_validate %}
+		<span
+			x-show="getError()"
+			x-text="value && getError()"
+			class="block text-sm font-medium text-center"
+			:class="{
+			  'text-red-500': serverError,
+			}"
+		></span>
+		{% endif %}
+	</div>
+
+	<div class="flex items-center relative">
+		<input type="hidden" name="username" x-model="value" />
+		<input
+			id="email"
+			type="email"
+			name="email"
+			x-model="value"
+			required
+			placeholder="{{ placeholder|default:'' }}"
+			class="w-full px-4 py-2 text-gray-700 border rounded-full focus:outline-none transition duration-150 ease-in-out bg-[#ECECEC]"
+		/>
+		{% if should_validate %}
+		<span
+			x-show="value && isValid"
+			class="text-green-500 text-xl font-semibold select-none absolute right-4"
+			>✓</span
+		>
+
+		<span
+			x-show="value && !isValid"
+			class="text-red-500 text-xl font-semibold select-none absolute right-4"
+			>✗</span
+		>
+		{% endif %}
+	</div>
+</div>


### PR DESCRIPTION
## 簡介
Email input 是一個 Django 模板標籤元件，用於生成標準化的電子郵件輸入欄位，提供即時驗證功能。

## 安裝
組件檔案需要放在以下路徑：
```
templatetags/
   input_tags.py
templates/
   components/
       email_input.html
```

## 使用方法
在模板中載入元件：
```django
{% load input_tags %}
```

基本使用：
```django
{% email_input verbose_name="電子郵件:" %}
```

## 參數說明
| 參數 | 類型 | 預設值 | 描述 |
|------|------|--------|------|
| value | str | "" | 輸入欄位的值 |
| error | str | "" | 錯誤訊息 |
| validate | bool | True | 是否啟用即時驗證 | 
| verbose_name | str | "Email" | 輸入欄位的標籤文字 |
| placeholder | str | "" | 提示文字 |

## 使用範例

### 基本表單
```django
{% email_input 
   verbose_name="電子郵件:"
   placeholder="請輸入電子郵件"
%}
```

### 與 Django Form 結合
```django
{% email_input 
   value=form.email.value
   error=form.email.errors.0
   verbose_name="電子郵件"
%}
```

### 不需驗證的欄位
```django
{% email_input 
   verbose_name="電子郵件"
   validate=False
%}
```

## 原始碼
```python
@register.inclusion_tag('components/email_input.html')
def email_input(value=None, error=None, should_validate=True, verbose_name=None, placeholder=None):
   return {
       'value': value,
       'error': error,
       'validate': should_validate,
       'verbose_name': verbose_name,
       'placeholder': placeholder
   }
```