### PR TITLE
C-style:layout fine-tuning, 修正setting, 加入必要套件requests

### DIFF
--- a/activities/templates/activities/create.html
+++ b/activities/templates/activities/create.html
@@ -9,7 +9,6 @@ tailwindcss 問題 CDN 佔掛
 link 等shared 健全後修改統一
 {% endcomment %}
     <style>
-        /* 自訂主色系 */
         :root {
             --moordule-yellow: #F6D246;
             --moordule-gray: #ECECEC;
@@ -38,25 +37,25 @@ link 等shared 健全後修改統一
     <header class="bg-yellow-500 text-white text-center py-4 text-2xl font-bold">
         建立聚會
     </header>
-
-
  
-
 
  <form method="POST" class="space-y-4">
             {% csrf_token %}
   
-    <main class="max-w-screen-lg mx-auto mt-8 bg-yellow-300 p-8 rounded-lg shadow-md space-y-8">
-        
-        <div class="flex space-x-6">
-            <div class="w-1/3">
+    <main class="max-w-7xl mx-auto mt-8 bg-yellow-300 p-8 rounded-lg shadow-md space-y-8">
+     {% comment "" %}分成三等份區域 {% endcomment %}
+        <div class="grid grid-cols-3 gap-6">
+          {% comment "" %}第一區：照片、聚會名稱、興趣 {% endcomment %}
+             <div>
+             <div class="bg-white rounded-card">
                 <div class="bg-gray-200 rounded-card flex flex-col items-center">
                     <p class="text-center text-gray-700">聚會 photo</p>
                     <i class="fi fi-br-add-image"></i>
                     <div class="bg-gray-300 w-32 h-32 flex items-center justify-center rounded-full mt-4">
                         <i class="fi fi-rr-camera text-gray-600 text-3xl"></i>
                     </div>
-                </div>
+                </div>     
+            </div>
                 <div class="bg-white rounded-card mt-6">
                     <label class="block font-bold text-gray-800 mb-2">聚會名稱：</label>
                     <input type="text" id="title" name="title" value="{{ form_data.title|default:'' }}" required 
@@ -69,19 +68,16 @@ link 等shared 健全後修改統一
                             <option value="{{ category.id }}" {% if form.category.value == category.id %}selected{% endif %}>{{ category.name }}</option>
                         {% endfor %}
                     </select>
-
-
                 </div>
             </div>
-
-            
-            <div class="flex-1 space-y-6">
-                <div class="bg-white rounded-card">
+{% comment "" %}第二區：時間、地點、人數等{% endcomment %}
+    
+            <div class="bg-white rounded-card space-y-6">
                     <h2 class="text-lg font-bold text-gray-800 mb-4">聚會設定</h2>
                     
                     <p class="text-gray-700">開始時間：</p>
                     <input type="datetime-local" id="start_time" name="start_time" value="{{ form_data.start_time|default:'' }}" required
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
                      {% if form.start_time.errors %}
                         <ul class="errorlist">
                             {% for error in form.start_time.errors %}
@@ -92,7 +88,7 @@ link 等shared 健全後修改統一
 
                     <p class="text-gray-700">聚會地點（地址）：</p>
                     <input type="text" id="address" name="address" value="{{ form_data.address|default:'' }}" required
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
                     
                     <p class="text-gray-700">聚會時長（小時）：</p>
                     <input type="number" id="duration" name="duration" value="{{ form_data.duration|default:1 }}" min="1" required
@@ -102,37 +98,34 @@ link 等shared 健全後修改統一
 
                     <p class="text-gray-700">參加人數：</p>
                     <input type="number" id="max_participants" name="max_participants" value="{{ form_data.max_participants|default:10 }}" min="1" required
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
-    
-                    
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">   
                 </div>
-                    <div class="bg-white rounded-card">
+{% comment "" %}第三區：聚會描述、創建規則與扣錢規則{% endcomment %}
+           
+    <div>
+            <div class="bg-white rounded-card space-y-6">
                     <h2 class="text-lg font-bold text-gray-800 mb-4">聚會詳細</h2>
                     <p class="text-gray-700">內容描述：</p>
-
                     <textarea id="description" name="description" required
                         class="w-full px-4 py-2 mt-2 rounded-md border border-gray-300 focus:outline-none focus:ring focus:ring-yellow-500">
                         {{ form_data.description|default:'' }}
                     </textarea>
-</div>
-
-            </div>
-        </div>
-
-        
-       
-        <div class="bg-white rounded-card text-center py-4">
-            <p class="text-gray-800 mb-4">創建聚會規則與扣 $ 規則</p>
+             </div>
+             <br>
+             <div class="bg-white rounded-card text-center py-4">
+                <p class="text-gray-800 mb-4">創建聚會規則與扣 $ 規則</p>
                <p class="text-gray-700">聚會規則內容：**待更新** Lorem ipsum dolor sit amet consectetur,
                 adipisicing elit. Reprehenderit sapiente eius provident eos obcaecati, quibusdam possimus tempora
                  sit laborum amet dolorum quae facilis tempore dolorem vitae! Vero laborum dolor vel? </p>
             <input type="checkbox" id="agree" name="agree"  required>
             <label for="agree" class="text-gray-800">我已詳細閱讀並了解規則</label>
             <br>
-            <button class="mt-4 w-1/2 py-3 bg-yellow-500 text-white rounded-full hover:bg-yellow-600">
+         
+            <button class="mt-4 w-full py-3 bg-yellow-500 text-white rounded-full hover:bg-yellow-600">
                 建立
             </button>
-        </div>
+            </div>
+       </div>
     </main>
 </form>
 </body>

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,6 +29,17 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "certifi"
+version = "2024.12.14"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
+    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
+]
+
+[[package]]
 name = "cffi"
 version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
@@ -409,6 +420,20 @@ files = [
 license = ["ukkonen"]
 
 [[package]]
+name = "idna"
+version = "3.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.5"
 description = "A very fast and expressive template engine."
@@ -707,6 +732,27 @@ files = [
 prompt_toolkit = ">=2.0,<=3.0.36"
 
 [[package]]
+name = "requests"
+version = "2.32.3"
+description = "Python HTTP for Humans."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 description = "A non-validating SQL parser."
@@ -769,6 +815,23 @@ files = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.3.0"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
+    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "virtualenv"
 version = "20.28.0"
 description = "Virtual Python Environment builder"
@@ -802,4 +865,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "9834fc62b38c66a7367c66bfd629e5a31dd94024d5eaf71a97a13190cc7d31d1"
+content-hash = "0b68f37f44f191e1d40e48f30a5f30d889ad6d77e8cbb101cdaf2f90c16ead5e"

--- a/pydev/settings.py
+++ b/pydev/settings.py
@@ -2,26 +2,15 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
+load_dotenv()
 
-# for 第三方們的 API 串接
-import environ
-env = environ.Env()
-environ.Env.read_env()
-
-# google登入：獲取 ALLOWED_HOSTS 的值，默認為 '*'
 allowed_hosts_env = os.getenv('ALLOWED_HOSTS', '*').split(',')
-
-# LINE PAY API 的
-line_pay_hostname = env('HOSTNAME')
-
-# 合併兩者的值
+line_pay_hostname =  os.getenv('HOSTNAME')
 ALLOWED_HOSTS = allowed_hosts_env + [line_pay_hostname]
 
-#LINE PAY API 的 CSRF_TRUSTED_ORIGINS
-CSRF_TRUSTED_ORIGINS = [f"https://{env('HOSTNAME')}"]
+CSRF_TRUSTED_ORIGINS = [f"https://{os.getenv('HOSTNAME')}"]
 
-# 加載環境變量
-load_dotenv()
+ 
 AUTH_USER_MODEL = "users.CustomUser"
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 DEBUG = os.getenv('DEBUG', 'True') == 'True'
@@ -41,7 +30,7 @@ db_url = os.getenv("DATABASE_URL")
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-jvpy^z_uod9g^p8i^ob%ee)mvc2s@#+oj-h3pzw5yq1&_^%xo5"
+SECRET_KEY =  os.getenv("SECRET_KEY")
 
 ALLOWED_HOSTS = []
 
@@ -61,11 +50,10 @@ INSTALLED_APPS = [
     "shared",
     "activities",
     "cashflows",
-    # 第三方套件
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-    'allauth.socialaccount.providers.google',  # Google 登入提供者
+    'allauth.socialaccount.providers.google', 
 ]
 
 AUTHENTICATION_BACKENDS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ cryptography = "^44.0.0"
 pyjwt = "^2.10.1"
 python-dotenv = "^1.0.1"
 psycopg = "^3.2.3"
+requests = "^2.32.3"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
#224 
- [ ] 聚會頁面排版微 如圖分三等 並 橫向展開

<img width="1344" alt="截圖 2024-12-24 上午11 08 42" src="https://github.com/user-attachments/assets/21ab826b-d9be-4e61-8a13-66a14583f3cd" />

setting.py 
- [ ] 拿掉重複load .env的功能
- [ ] 拿掉多餘的註解

pyproject.toml, poetry.lock
- [ ] 加入三方必要套件requests
後續給 #202 結合圖片功能

