### PR TITLE
R-feat: 瀏覽器導航按鈕同步更新/限制已登入用戶訪問登入/註冊頁面

### DIFF
--- a/shared/templates/shared/navigator.html
+++ b/shared/templates/shared/navigator.html
@@ -1,25 +1,36 @@
 <nav
+	id="user-navigator"
 	class="space-x-5 flex justify-center items-center mt-5 mx-auto w-max pt-20"
-	x-data="{ activeButton: '{{ current_tag }}' }"
+	x-data="{ 
+        active: window.location.pathname.split('/')[2] || 'member',
+        init() {
+            window.addEventListener('popstate', () => {
+                this.active = window.location.pathname.split('/')[2] || 'member';
+            });
+        }
+    }"
+	x-init="init()"
 >
 	{% for item in nav_items %}
 	<!-- prettier-ignore -->
 	<a
+        :key="{{ item.name }}"
         {% if item.url %}
         hx-get="{% url 'users:user_page' item.url %}"
-        {% else %}
+        {% else %}  
         hx-get="{% url 'users:account' %}"
         {% endif %}
         hx-target="#main-content"
         hx-push-url="true"
     >
         <button
-            @click="activeButton = '{{ item.name }}'"
+            x-data="{ itemName: '{{ item.name }}' }"
+            @click="active = itemName"
             class="px-6 py-3 rounded-full hover:bg-yellow-500 text-white text-xl"
-            :class="activeButton === '{{ item.name }}' ? 'bg-yellow-500' : 'bg-yellow-300'"
+            :class="{ 'bg-yellow-500': active === itemName, 'bg-yellow-300': active !== itemName }"
         >
             {{ item.title }}
         </button>
-   </a>
+    </a>
 	{% endfor %}
 </nav>

--- a/shared/templatetags/navigation.py
+++ b/shared/templatetags/navigation.py
@@ -5,10 +5,6 @@ register = template.Library()
 
 @register.inclusion_tag("shared/navigator.html", takes_context=True)
 def navigator(context):
-    request = context["request"]
-
-    path = request.path.strip("/")
-    current_tag = "member" if path == "users" else path.split("/")[-1]
 
     nav_items = [
         {"title": "我的頁面", "url": "", "name": "member"},  # member 的 url 為空
@@ -16,4 +12,4 @@ def navigator(context):
         {"title": "我的活動", "url": "activities", "name": "activities"},
         {"title": "創建活動", "url": "activity_form", "name": "activity_form"},
     ]
-    return {"nav_items": nav_items, "current_tag": current_tag}
+    return {"nav_items": nav_items}

--- a/users/decorators.py
+++ b/users/decorators.py
@@ -1,0 +1,17 @@
+from django.contrib import messages
+from django.shortcuts import redirect
+
+
+def anonymous_required(view_func=None, /, *, redirect_url="pages:index"):
+    def decorator(view_func):
+        def wrapper(request, *args, **kwargs):
+            if request.user.is_authenticated:
+                messages.warning(request, "您已登入，無法存取此頁面")
+                return redirect(redirect_url)
+            return view_func(request, *args, **kwargs)
+
+        return wrapper
+
+    if view_func is None:
+        return decorator
+    return decorator(view_func)

--- a/users/views.py
+++ b/users/views.py
@@ -9,6 +9,7 @@ from django_htmx.middleware import HtmxDetails
 
 from activities.models import Activity as Meetup
 
+from .decorators import anonymous_required
 from .forms import AboutMeForm, CustomUserChangeForm, UserRegistrationForm
 
 
@@ -55,6 +56,7 @@ def password_change_view(request):
 
     return render(request, "users/components/password.html", {"user": user})
 
+
 @login_required
 def user_page_view(request, tag="member"):
     form = CustomUserChangeForm()
@@ -86,6 +88,7 @@ def upload_view(request: HttpRequest):
     return JsonResponse({"status": "error", "message": "上傳失敗"}, status=400)
 
 
+@anonymous_required
 def signup_view(request: HttpRequest):
 
     if request.POST:
@@ -102,6 +105,7 @@ def signup_view(request: HttpRequest):
     return render(request, "users/signup.html", {"meetups": meetups})
 
 
+@anonymous_required
 def signin_view(request: HttpRequest):
     meetups = Meetup.objects.filter(start_time__gte=timezone.now()).order_by(
         "start_time"


### PR DESCRIPTION
### 1. 瀏覽器導航控制
- **問題**: 瀏覽器的後退/前進按鈕無法同步更新導航欄UI狀態
- **原因**: Alpine.js 的狀態在 popstate 事件時未正確更新
- **解決方案**: 在 Navigator 組件中加入瀏覽器導航事件處理

### 2. 身分驗證頁面存取控制
- **問題**: 已登入用戶可以通過直接輸入 URL 訪問登入/註冊頁面
- **原因**: 頁面路由缺少身分驗證狀態檢查
- **解決方案**: 實作裝飾器來限制已認證用戶的存取權限