### PR TITLE
J-fix:add js & map into build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"activities": "esbuild ./src/script/activities.js --bundle --outfile=static/dist/activities.js",
 		"map": "esbuild ./src/script/map.js --bundle --outfile=static/src/map.js",
 		"dev": "npm-run-all --parallel css js activities map",
-		"build": "tailwindcss -i ./src/style/main.css -o ./static/dist/bundle.css && esbuild ./src/script/activities.js --bundle --outfile=static/dist/activities.js"
+		"build": "tailwindcss -i ./src/style/main.css -o ./static/dist/bundle.css && esbuild ./src/script/activities.js --bundle --outfile=static/dist/activities.js && esbuild ./src/script/main.js --bundle --outfile=static/dist/bundle.js && esbuild ./src/script/map.js --bundle --outfile=static/src/map.js"
 	},
 	"author": "",
 	"license": "ISC",


### PR DESCRIPTION
#44
將 js & map 指令加入 “build”之中，讓指令在部署可以被執行