### PR TITLE
Ｃ-fix:all adjustments for the card pages and others

### DIFF
--- a/activities/templates/activities/confirm_delete.html
+++ b/activities/templates/activities/confirm_delete.html
@@ -1,68 +1,103 @@
-{% extends 'base/layout.html' %}
+{% extends "base/layout.html" %}
 {% load static %}
 {% block head %}
     <title>刪除聚會</title>
-{% endblock %}
+    <script src="https://maps.googleapis.com/maps/api/js?key={{google_maps_api_key}}&callback=initMap&loading=async" async defer></script>
+    <script src="{% static 'src/map.js' %}"></script>
+{% endblock head %}
 
 {% block content %}
-<div class="pt-20 mx-auto w-full max-w-4xl">
+<div class="bg-white text-gray-900">
+    <!-- 特別聚會 banner -->
+    <section id="top">
+        <img src="https://images.unsplash.com/photo-1541379889336-70f26e4c4617?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y2hpbmVzZSUyMG5ldyUyMHllYXJ8ZW58MHx8MHx8fDA%3D" alt="chinese new year" class="w-full h-[70vh] object-cover">
+    </section>
 
-    <div class="max-w-7xl mx-auto mt-8 bg-moordule-yellow p-8 rounded-[24px] shadow-md space-y-8">
-       <div class="bg-white rounded-[24px]">
-       <br>
-       <h1 class="flex justify-center  text-4xl text-moordule-pink">刪除確認</h1>
-                <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
-                    <div class="w-full sm:w-1/2 md:w-1/3 lg:w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                        <!-- 卡牌內容 -->
-                        <div class=" bg-moordule-pink p-4 shadow-md rounded-[24px]">
-                            <h3 class="text-xl text-red-600 text-center">您確定要刪除聚會 <strong>{{ activity.title }}</strong> 嗎？</h3>
-                            
-                            <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover " />
-                            
-                            <div class="mb-4">
-                                <strong>{{ activity.title }}</strong><br>
-                                地址：{{ activity.address }}<br>
-                                開始時間：{{ activity.start_time|date:"Y-m-d H:i" }}<br>
-                                持續時間：{{ activity.duration }} 小時<br>
-                                參加人數上限：{{ activity.max_participants }}<br>
-                                預計結束時間：{{ activity.end_time|date:"Y-m-d H:i" }}<br>
-                                建立時間：{{ activity.created_at|date:"Y-m-d H:i" }}<br>
-                            </div>
+    <!-- 按鈕去各區 -->
+    <div class="flex justify-center space-x-10 my-10">
+        <a href="{% url 'activities:eating' %}">
+            <button class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500">
+                揪吃飯
+            </button>
+        </a>
+        <a href="{% url 'activities:driking' %}">
+            <button class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500">
+                揪喝酒
+            </button>
+        </a>
+        <a href="{% url 'activities:sports' %}">
+            <button class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500">
+                揪運動
+            </button>
+        </a>
+        <a href="{% url 'activities:singing' %}">
+            <button class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500">
+                揪唱歌
+            </button>
+        </a>
+        <a href="{% url 'activities:movies' %}">
+            <button class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500">
+                揪電影
+            </button>
+        </a>
+        <a href="{% url 'activities:discussion' %}">
+            <button class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500">
+                揪討論
+            </button>
+        </a>
+    </div>
 
-                            <div class="flex justify-between items-center mb-2">
-                                <div class="flex items-center gap-1">
-                                    <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                                        <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/>
-                                    </svg>
-                                    <span>已參加{{ activity.participants.count }} / {{ activity.max_participants }}人</span>
-                                </div>
-                            </div>
+    <!-- 聚會資訊 -->
+    <div class="bg-yellow-300 rounded-3xl h-[600px] overflow-hidden shadow-lg mx-20">
+        <div class="px-10 py-10 flex row rounded-3xl gap-4 h-full">
+            <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="basis-1/3 rounded-s-3xl bg-white object-cover">
 
-                            <div class="flex justify-between gap-2 text-sm mb-2">
-                                <div class="flex">
-                                    <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                                        <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
-                                    </svg>
-                                    <p>地點: {{ activity.address }}</p>
-                                </div>
-                                <p>時間: {{ activity.start_time|date:"Y-m-d H:i" }}</p>
-                            </div>
-
-                            <span class="text-lg font-medium">聚會內容：</span>
-                            <p class="text-sm mb-4 text-lg">{{ activity.description }}</p>
-
-                            <form method="POST" class="mt-4">
-                                {% csrf_token %}
-                                <button type="submit" class="w-full py-2 mt-4 rounded-full bg-gray-300 text-white-shadow font-bold text-center block">確定刪除</button>
-                            </form>
-
-                            <a href="{% url 'users:user_page' tag='my_activities' %}" class="w-full py-2 mt-4 rounded-full bg-gray-300 text-white-shadow font-bold text-center block">取消</a>
-                        </div>
+            <div class="basis-2/3 rounded-r-3xl bg-white px-8 py-6">
+                <div class="flex justify-between items-center mb-2">
+                    <h3 class="font-bold text-2xl">{{ activity.title }}</h3>
+                    <div class="flex items-center gap-1">
+                        <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                            <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"></path>
+                        </svg>
+                        <span class="text-lg">已參加{{ activity.participants.count }} / 最多{{ activity.max_participants }}人</span>
                     </div>
                 </div>
-                <br>
 
-        
+                <div class="flex justify-between gap-2 text-sm mb-2">
+                    <div class="flex">
+                        <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+                        </svg>
+                        <span class="text-lg">{{ activity.address }}</span>
+                    </div>
+                    <div class="flex gap-8">
+                        <span class="text-lg">聚會日期：{{ activity.start_time|date:"Y-m-d" }}</span>
+                        <span class="text-lg">聚會時間：{{ activity.start_time|date:"H:i" }}</span>
+                    </div>
+                </div>
+
+                <div class="gap-4 pb-6 flex h-[200px] pt-4">
+                    <div >
+                        <span class="text-xl font-medium">聚會內容：</span>
+                        <p class="text-lg mb-4 text-lg">{{ activity.description }}</p>
+                    </div>
+                    
+                      <!-- 刪除區塊 -->
+                </div>
+                <div>
+                <form method="POST" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" name="delete" class="w-full rounded-full text-white-shadow bg-moordule-pink font-bold p-2">確定刪除聚會</button>
+                </form>
+                <br>
+                <a href="{% url 'users:user_page' tag='my_activities' %}">
+                    <button type="button" class="w-full rounded-full text-white-shadow bg-moordule-yellow font-bold p-2">取消</button>
+                </a>
+                </div>
+              
+
+            </div>
+        </div>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/activities/templates/activities/confirm_delete.html
+++ b/activities/templates/activities/confirm_delete.html
@@ -1,27 +1,68 @@
 {% extends 'base/layout.html' %}
 {% load static %}
 {% block head %}
-    <title>activities</title>
+    <title>刪除聚會</title>
 {% endblock %}
 
 {% block content %}
-<div>
-    <h1>刪除確認</h1>
-<p>您確定要刪除聚會 <strong>{{ activity.title }}</strong> 嗎？</p>
-<strong>{{ activity.title }}</strong><br>
-                    地址：{{ activity.address }}<br>
-                    開始時間：{{ activity.start_time|date:"Y-m-d H:i" }}<br>
-                    持續時間：{{ activity.duration }} 小時<br>
-                    參加人數上限：{{ activity.max_participants }}<br>
-                    預計結束時間：{{ activity.end_time|date:"Y-m-d H:i" }}<br>
-                    建立時間：{{ activity.created_at|date:"Y-m-d H:i" }}<br>
+<div class="pt-20 mx-auto w-full max-w-4xl">
 
-<form method="POST">
-    {% csrf_token %}
-    <button type="submit">確定刪除</button>
-    <br>
-     <a href="{% url 'users:user_page' tag='my_activities' %}">取消</a>
-</form>
+    <div class="max-w-7xl mx-auto mt-8 bg-moordule-yellow p-8 rounded-[24px] shadow-md space-y-8">
+       <div class="bg-white rounded-[24px]">
+       <br>
+       <h1 class="flex justify-center  text-4xl text-moordule-pink">刪除確認</h1>
+                <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
+                    <div class="w-full sm:w-1/2 md:w-1/3 lg:w-1/5 rounded-3xl overflow-hidden shadow-lg">
+                        <!-- 卡牌內容 -->
+                        <div class=" bg-moordule-pink p-4 shadow-md rounded-[24px]">
+                            <h3 class="text-xl text-red-600 text-center">您確定要刪除聚會 <strong>{{ activity.title }}</strong> 嗎？</h3>
+                            
+                            <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover " />
+                            
+                            <div class="mb-4">
+                                <strong>{{ activity.title }}</strong><br>
+                                地址：{{ activity.address }}<br>
+                                開始時間：{{ activity.start_time|date:"Y-m-d H:i" }}<br>
+                                持續時間：{{ activity.duration }} 小時<br>
+                                參加人數上限：{{ activity.max_participants }}<br>
+                                預計結束時間：{{ activity.end_time|date:"Y-m-d H:i" }}<br>
+                                建立時間：{{ activity.created_at|date:"Y-m-d H:i" }}<br>
+                            </div>
 
+                            <div class="flex justify-between items-center mb-2">
+                                <div class="flex items-center gap-1">
+                                    <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                                        <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/>
+                                    </svg>
+                                    <span>已參加{{ activity.participants.count }} / {{ activity.max_participants }}人</span>
+                                </div>
+                            </div>
+
+                            <div class="flex justify-between gap-2 text-sm mb-2">
+                                <div class="flex">
+                                    <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                                        <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+                                    </svg>
+                                    <p>地點: {{ activity.address }}</p>
+                                </div>
+                                <p>時間: {{ activity.start_time|date:"Y-m-d H:i" }}</p>
+                            </div>
+
+                            <span class="text-lg font-medium">聚會內容：</span>
+                            <p class="text-sm mb-4 text-lg">{{ activity.description }}</p>
+
+                            <form method="POST" class="mt-4">
+                                {% csrf_token %}
+                                <button type="submit" class="w-full py-2 mt-4 rounded-full bg-gray-300 text-white-shadow font-bold text-center block">確定刪除</button>
+                            </form>
+
+                            <a href="{% url 'users:user_page' tag='my_activities' %}" class="w-full py-2 mt-4 rounded-full bg-gray-300 text-white-shadow font-bold text-center block">取消</a>
+                        </div>
+                    </div>
+                </div>
+                <br>
+
+        
+    </div>
 </div>
 {% endblock %}

--- a/activities/templates/activities/create.html
+++ b/activities/templates/activities/create.html
@@ -44,10 +44,10 @@
 
    
 
- <form method="POST" class="mt-12 max-w-screen-lg mx-auto" enctype="multipart/form-data">
+ <form method="POST" class="mt-12 max-w-7xl mx-auto" enctype="multipart/form-data">
   {% csrf_token %}
+<div class="max-w-7xl  mx-auto mt-8 bg-moordule-yellow  p-8 rounded-[24px]  shadow-md space-y-8">
 
-<div class="max-w-7xl mx-auto mt-8 bg-yellow-300 p-8 rounded-[24px]  shadow-md space-y-8">
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-6">
    <div>
    <div class="bg-white rounded-[24px] rounded-card p-6">

--- a/activities/templates/activities/discussion.html
+++ b/activities/templates/activities/discussion.html
@@ -19,44 +19,44 @@
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
   <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+   <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -72,8 +72,8 @@
           <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
             {% for activity in activities %}
               <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="https://picsum.photos/200/300" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-deep-blue p-4">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-deep-blue p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/driking.html
+++ b/activities/templates/activities/driking.html
@@ -19,44 +19,44 @@
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
   <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -72,8 +72,8 @@
           <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
             {% for activity in activities %}
               <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="https://picsum.photos/200/300" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-yellow p-4">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-yellow p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/eating.html
+++ b/activities/templates/activities/eating.html
@@ -19,44 +19,44 @@
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
   <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+     <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -72,8 +72,8 @@
           <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
             {% for activity in activities %}
               <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="https://picsum.photos/200/300" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-pink p-4">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-pink p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/index.html
+++ b/activities/templates/activities/index.html
@@ -19,44 +19,44 @@
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
   <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -76,7 +76,7 @@
             {% for activity in activities %}
               <div class="w-80 rounded-3xl overflow-hidden shadow-lg">
                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-pink p-4">
+                <div class="bg-moordule-pink p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">
@@ -133,7 +133,7 @@
             {% for activity in activities %}
               <div class="w-80 rounded-3xl overflow-hidden shadow-lg">
                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                 <div class="bg-yellow-300 p-4">
+                 <div class="bg-yellow-300 p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">
@@ -188,7 +188,7 @@
             {% for activity in activities %}
               <div class="w-80 rounded-3xl overflow-hidden shadow-lg">
                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                 <div class="bg-moordule-deep-blue p-4">
+                 <div class="bg-moordule-deep-blue p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">
@@ -244,7 +244,7 @@
             {% for activity in activities %}
               <div class="w-80 rounded-3xl overflow-hidden shadow-lg">
                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-yellow p-4">
+                <div class="bg-moordule-yellow p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">
@@ -303,7 +303,7 @@
             {% for activity in activities %}
               <div class="w-80 rounded-3xl overflow-hidden shadow-lg">
                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                 <div class="bg-moordule-pink p-4">
+                 <div class="bg-moordule-pink p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">
@@ -357,7 +357,7 @@
             {% for activity in activities %}
               <div class="w-80 rounded-3xl overflow-hidden shadow-lg">
                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                 <div class="bg-moordule-deep-blue p-4">
+                 <div class="bg-moordule-deep-blue p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/information.html
+++ b/activities/templates/activities/information.html
@@ -16,44 +16,44 @@
     <!-- 按鈕去各區 -->
    <!-- 按鈕去各區 -->
   <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -106,17 +106,6 @@
                  <!-- 第四排 -->
                 {% if request.user.is_authenticated %}
 
-                        <form method="post" class="d-inline">
-                            {% csrf_token %}
-                            <button type="submit" name="join" class="w-full rounded-full text-white-shadow bg-[#F78888] font-bold p-2">加入聚會</button>
-                        </form>
-
-                    {% else %}
-                     <a href="{% url 'users:signin' %}">
-                    <button type="button" class="w-full rounded-full text-white-shadow bg-[#F78888] font-bold">請先登入以參加聚會</button>
-                    </a>
-                    {% endif %}
-
                     {% if message %}
                         <p class="text-center alert alert-success">{{ message }}</p>
                     {% endif %}
@@ -124,6 +113,19 @@
                     {% if error_message %}
                         <p class="text-center alert alert-danger">{{ error_message }}</p>
                     {% endif %}
+
+
+                        <form method="post" class="d-inline"  action="#infortop">
+                            {% csrf_token %}
+                            <button type="submit" name="join" class="w-full rounded-full text-white-shadow bg-moordule-pink font-bold p-2">加入聚會</button>
+                        </form>
+
+                    {% else %}
+                     <a href="{% url 'users:signin' %}">
+                    <button type="button" class="w-full rounded-full text-white-shadow bg-moordule-pink font-bold">請先登入以參加聚會</button>
+                    </a>
+                    {% endif %}
+
 
 
 

--- a/activities/templates/activities/movies.html
+++ b/activities/templates/activities/movies.html
@@ -19,44 +19,44 @@
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
   <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -72,8 +72,8 @@
           <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
             {% for activity in activities %}
               <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="https://picsum.photos/200/300" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-pink p-4">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-pink p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/search.html
+++ b/activities/templates/activities/search.html
@@ -16,102 +16,93 @@
     />
   </section>
   <!-- 按鈕去各區 -->
-  <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+ <div class="flex justify-center space-x-10 my-10">
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
     >
-  </div>
+  </div> 
 
   <section>
     <h1 class="flex justify-center text-4xl">搜尋結果:{{ keyword }}</h1>
 
     <!-- 卡牌樣式 -->
     {% if activities %}
-    <div id="drink" class="mx-20 pt-12">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div  class="justify-center mx-20 pt-12">
+      <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
         <!-- Card -->
-        {% for activty in activities %}
-        <div class="rounded-3xl overflow-hidden shadow-lg bg-white">
-          <img
-            src="https://miro.medium.com/v2/resize:fit:630/format:webp/1*5xh2fKvJByPlTheZik_VCg.jpeg"
-            alt="pizza"
-            class="h-48 w-full object-cover"
-          />
-          <div class="bg-yellow-300 p-6">
-            <div class="flex justify-between items-center mb-4">
-              <h3 class="font-bold text-xl">{{activty.title}}</h3>
-              <div class="flex items-center gap-1">
-                <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                  <path
-                    d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                  />
-                </svg>
-                <span>20</span>
+        {% for activity in activities %}
+              <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg ">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}"  class="h-48 w-full object-cover" />
+                <div class="bg-moordule-yellow p-4  h-full">
+                  <div class="flex justify-between items-center mb-2">
+                    <h3>{{ activity.title }}</h3>
+                    <div class="flex items-center gap-1">
+                      <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/>
+                      </svg>
+                        <span>已參加{{ activity.participants.count }} / {{ activity.max_participants }}人</span>
+                    </div>
+                  </div>
+                  <div class="flex justify-between gap-2 text-sm mb-2">
+                    <div class="flex">
+                      <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+                      </svg>
+                      <p>地點: {{ activity.address }}</p>
+                    </div>
+                    <p>時間: {{ activity.start_time|date:"Y-m-d H:i" }}</p>
+                  </div>
+                  <span class="text-lg font-medium">聚會內容：</span>
+                  <p class="text-sm mb-4 text-lg">
+                    {{ activity.description }}
+                  </p>
+                  <a href="{% url 'activities:join' activity.id %} "  
+                  >
+                <button class="w-full py-2 rounded-full bg-white text-moordule-yellow font-bold">馬上揪</button>
+                </a>
+                </div>
               </div>
-            </div>
-            <div class="flex justify-between items-center text-sm mb-4">
-              <div class="flex items-center gap-2">
-                <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-                  <path
-                    fill-rule="evenodd"
-                    d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-                <span>{{activty.address}}</span>
-              </div>
-              <span class="text-sm">{{activty.created_at}}</span>
-            </div>
-            <p class="text-sm mb-4">{{activty.description}}</p>
-            <button
-              class="w-full py-2 rounded-full bg-white text-yellow-500 font-bold"
-            >
-              馬上揪
-            </button>
+            {% endfor %}
           </div>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
     {% else %}
     <h3 class="flex justify-center text-2xl p-8 text-red text-center">
       沒有找到相關結果。
@@ -119,4 +110,26 @@
     {% endif %}
   </section>
 </div>
+
+          <!-- 分頁導航 -->
+          <div class="pagination mt-8 mb-4 flex justify-center">
+            <span class="step-links">
+                {% if activities.has_previous %}
+                    <a href="?page_{{ category.id }}={{ activities.previous_page_number }}" class="mx-2 font-bold text-2xl "> < </a>
+                {% endif %}
+
+                {% for num in activities.paginator.page_range %}
+                    {% if num == activities.number %}
+                        <span class="mx-2 font-bold text-2xl"> {{ num }} </span>  <!-- 當前頁碼 -->
+                    {% else %}
+                        <a href="?page_{{ category.id }}={{ num }}" class="mx-2 font-bold text-2xl"> {{ num }} </a>
+                    {% endif %}
+                {% endfor %}
+
+                {% if activities.has_next %}
+                    <a href="?page_{{ category.id }}={{ activities.next_page_number }}" class="mx-2 text-2xl font-bold"> > </a>
+                {% endif %}
+            </span>
+          </div>
+          
 {% endblock content %}

--- a/activities/templates/activities/singing.html
+++ b/activities/templates/activities/singing.html
@@ -18,45 +18,45 @@
   
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
-  <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+   <div class="flex justify-center space-x-10 my-10">
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
@@ -72,8 +72,8 @@
           <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
             {% for activity in activities %}
               <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="https://picsum.photos/200/300" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-yellow p-4">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-yellow p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/sports.html
+++ b/activities/templates/activities/sports.html
@@ -18,50 +18,50 @@
   
   {% comment %} <!-- 按鈕去各區 --> {% endcomment %}
 
-  <div class="flex justify-center space-x-10 my-10">
-    <a href="#eat"
+ <div class="flex justify-center space-x-10 my-10">
+    <a href="{% url 'activities:eating' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪吃飯
       </button></a
     >
-    <a href="#drink"
+    <a href="{% url 'activities:driking' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪喝酒
       </button></a
     >
-    <a href="#sports"
+     <a href="{% url 'activities:sports' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪運動
       </button></a
     >
-    <a href="#sing"
+    <a href="{% url 'activities:singing' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-yellow-300 text-white-shadow hover:bg-yellow-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-yellow text-white-shadow hover:bg-yellow-500"
       >
         揪唱歌
       </button></a
     >
-    <a href="#movies"
+    <a href="{% url 'activities:movies' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#F78888] text-white-shadow hover:bg-pink-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-pink text-white-shadow hover:bg-pink-500"
       >
         揪電影
       </button></a
     >
-    <a href="#seminer"
+    <a href="{% url 'activities:discussion' %}"
       ><button
-        class="text-xl px-4 py-1 rounded-full bg-[#5DA2D5] text-white-shadow hover:bg-blue-500"
+        class="text-xl px-4 py-1 rounded-full bg-moordule-deep-blue text-white-shadow hover:bg-blue-500"
       >
         揪討論
       </button></a
     >
-  </div>
+  </div> 
 
   <section>
     <h1 class="flex justify-center my-10 text-4xl">ㄧ起揪運動</h1>
@@ -72,8 +72,8 @@
           <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
             {% for activity in activities %}
               <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="https://picsum.photos/200/300" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-deep-blue p-4">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-deep-blue p-4 h-full">
                   <div class="flex justify-between items-center mb-2">
                     <h3>{{ activity.title }}</h3>
                     <div class="flex items-center gap-1">

--- a/activities/templates/activities/update.html
+++ b/activities/templates/activities/update.html
@@ -1,96 +1,110 @@
-{% extends "base/layout.html" %} 
+{% extends "base/layout.html" %}
+{% load static %}
 {% block head %}
     <title>更新聚會</title>
-{% endblock head %} 
+    <script type="module" src="{% static 'dist/activities.js' %}" defer></script>
+    <link rel='stylesheet' href='https://cdn-uicons.flaticon.com/2.6.0/uicons-bold-rounded/css/uicons-bold-rounded.css'>
+{% endblock head %}
 
 {% block content %}
-<div class="pt-20  mx-auto w-full max-w-4xl">
-    <h1 class="flex justify-center my-10 text-4xl">更新聚會</h1>
+<div class="pt-20">
 
-    <div class="max-w-7xl mx-auto mt-8 bg-yellow-300 p-8 rounded-[24px] shadow-md space-y-8">
-        {% if error_message %}
-            <p style="color: red;">{{ error_message }}</p>
-        {% endif %}
+    <nav class="space-x-5 flex justify-center items-center mt-5 mx-auto w-max">
+        <a href="{% url 'users:user_page' tag='member' %}">
+            <button class="px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:bg-yellow-500 text-white-shadow bg-moordule-yellow text-xl">
+                我的頁面
+            </button>
+        </a>
 
-       
+        <a href="{% url 'users:user_page' tag='account' %}">
+            <button class="px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:bg-yellow-500 text-white-shadow bg-moordule-yellow text-xl">
+                我的帳號
+            </button>
+        </a>
 
-        <!-- 表單區域開始 -->
-        <form method="POST" class="pt-8 ">
-            {% csrf_token %}
-            <div class="mb-4">
-                <label for="title" class="block text-gray-700">聚會標題：</label>
-                <input type="text" id="title" name="title" value="{{ activity.title }}" required class="w-full p-2 mt-2 border rounded">
-            </div>
+        <a href="{% url 'users:user_page' tag='activities' %}">
+            <button class="px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:bg-yellow-500 text-white-shadow bg-moordule-yellow text-xl">
+                我的聚會
+            </button>
+        </a>
 
-            <div class="mb-4">
-                <label for="description" class="block text-gray-700">聚會描述：</label>
-                <textarea id="description" name="description" class="w-full p-2 mt-2 border rounded">{{ activity.description }}</textarea>
-            </div>
+        <a href="{% url 'users:user_page' tag='my_activities' %}">
+            <button class="px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:bg-yellow-500 text-white-shadow bg-yellow-400 text-xl">
+                創建聚會
+            </button>
+        </a>
+    </nav>
 
-            <div class="mb-4">
-                <label for="address" class="block text-gray-700">聚會地址：</label>
-                <input type="text" id="address" name="address" value="{{ activity.address }}" required class="w-full p-2 mt-2 border rounded">
-            </div>
-
-            <div class="mb-4">
-                <label for="start_time" class="block text-gray-700">開始時間：</label>
-                <input type="datetime-local" id="start_time" name="start_time" value="{{ activity.start_time|date:"Y-m-d\TH:i" }}" required class="w-full p-2 mt-2 border rounded">
-            </div>
-
-            <div class="mb-4">
-                <label for="duration" class="block text-gray-700">持續時間（小時）：</label>
-                <input type="number" id="duration" name="duration" value="{{ activity.duration }}" min="1" required class="w-full p-2 mt-2 border rounded">
-            </div>
-
-            <div class="mb-4">
-                <label class="block font-bold text-gray-800 mb-2">聚會類別：</label>
-                {{ form.category }}
-                {% for error in form.category.errors %}
-                    <p style="color: red;">{{ error }}</p>
-                {% endfor %}
-            </div>
-
-            <div class="mb-4">
-                <label for="max_participants" class="block text-gray-700">參加人數上限：</label>
-                <input type="number" id="max_participants" name="max_participants" value="{{ activity.max_participants }}" min="1" required class="w-full p-2 mt-2 border rounded">
-            </div>
-
-            <button type="submit" class="w-full py-2 rounded-full bg-moordule-pink text-white font-bold">更新聚會</button>
-        </form>
-
-
-    <h3 class="flex justify-center my-10 text-4xl">原卡牌資訊</h3>
-         <!-- 卡牌顯示 -->
-        <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
-            <div class="w-full sm:w-1/2 md:w-1/3 lg:w-1/5 rounded-3xl overflow-hidden shadow-lg">
-                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
-                <div class="bg-moordule-pink p-4">
-                    <div class="flex justify-between items-center mb-2">
-                        <h3>{{ activity.title }}</h3>
-                        <div class="flex items-center gap-1">
-                            <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                                <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/>
-                            </svg>
-                            <span>已參加{{ activity.participants.count }} / {{ activity.max_participants }}人</span>
-                        </div>
+    <form method="POST" class="mt-12 max-w-7xl mx-auto" enctype="multipart/form-data">
+        {% csrf_token %}
+        
+        <div class="max-w-7xl mx-auto mt-8 bg-yellow-300 p-8 rounded-[24px]  shadow-md space-y-8">
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-6">
+                <div>
+                    <div class="bg-white rounded-[24px] rounded-card p-6">
+                        <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full  rounded-[24px] object-cover" />
                     </div>
-                    <div class="flex justify-between gap-2 text-sm mb-2">
-                        <div class="flex">
-                            <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                                <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
-                            </svg>
-                            <p>地點: {{ activity.address }}</p>
-                        </div>
-                        <p>時間: {{ activity.start_time|date:"Y-m-d H:i" }}</p>
+
+                    <div class="bg-white rounded-[24px] rounded-card mt-6 p-6">
+                        <label class="block font-bold text-gray-800 mb-2">聚會名稱：</label>
+                        <input type="text" id="title" name="title" value="{{ activity.title }}" required
+                               class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring focus:ring-yellow-500">
+                        
+                        <label class="block font-bold text-gray-800 mb-2 mt-4">類別：</label>
+                        <select name="category" id="category" class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring focus:ring-yellow-500">
+                            <option value="" disabled selected>選擇類別</option>
+                            {% for category in categories %}
+                                <option value="{{ category.id }}" {% if activity.category.id == category.id %}selected{% endif %}>{{ category.name }}</option>
+                            {% endfor %}
+                        </select>
                     </div>
-                   
-                    <span class="text-lg font-medium">聚會內容：</span>
-                    <p class="text-sm mb-4 text-lg">{{ activity.description }}</p>
+                </div>
+
+                <div class="bg-white rounded-[24px] rounded-card p-6 space-y-6">
+                    <h2 class="text-lg font-bold text-gray-800 mb-4">聚會設定</h2>
+
+                    <div class="space-y-3">
+                        <p class="text-gray-700">開始時間：</p>
+                        <input type="datetime-local" id="start_time" name="start_time" value="{{ activity.start_time|date:"Y-m-d\TH:i" }}" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                    </div>
+
+                    <div class="space-y-3">
+                        <p class="text-gray-700">聚會地點（地址）：</p>
+                        <input type="text" id="address" name="address" value="{{ activity.address }}" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                    </div>
+
+                    <div class="space-y-3">
+                        <p class="text-gray-700">聚會時長（小時）：</p>
+                        <input type="number" id="duration" name="duration" value="{{ activity.duration }}" min="1" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                    </div>
+
+                    <div class="space-y-3">
+                        <p class="text-gray-700">參加人數：</p>
+                        <input type="number" id="max_participants" name="max_participants" value="{{ activity.max_participants }}" min="1" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                    </div>
+                </div>
+
+                <div class="bg-white rounded-[24px] rounded-card p-6 space-y-6">
+                    <h2 class="text-lg font-bold text-gray-800 mb-4">聚會詳細</h2>
+                    <div class="space-y-3">
+                        <p class="text-gray-700">內容描述：</p>
+                        <textarea id="description" name="description" required
+                                  class="w-full px-4 py-2 mt-2 rounded-md border border-gray-300 focus:outline-none focus:ring focus:ring-yellow-500 min-h-[120px]">{{ activity.description }}</textarea>
+                    </div>
                 </div>
             </div>
+
+            
+                <button type="submit" class="mt-6 w-full py-3 bg-moordule-pink text-white-shadow rounded-full hover:bg-red-500 ">
+                    更新聚會
+                </button>
+            
         </div>
-
-
-    </div>
+    </form>
 </div>
+
 {% endblock content %}

--- a/activities/templates/activities/update.html
+++ b/activities/templates/activities/update.html
@@ -1,45 +1,96 @@
-
-{% extends "base/layout.html" %} {% block head %}
+{% extends "base/layout.html" %} 
+{% block head %}
     <title>更新聚會</title>
-{% endblock head %} {% block content %}
+{% endblock head %} 
 
-    <h1>更新聚會</h1>
-    {% if error_message %}
-        <p style="color: red;">{{ error_message }}</p>
-    {% endif %}
-    <form method="POST">
-        {% csrf_token %}
-        <label for="title">聚會標題：</label>
-        <input type="text" id="title" name="title" value="{{ activity.title }}" required><br>
+{% block content %}
+<div class="pt-20  mx-auto w-full max-w-4xl">
+    <h1 class="flex justify-center my-10 text-4xl">更新聚會</h1>
 
-        <label for="description">聚會描述：</label>
-        <textarea id="description" name="description">{{ activity.description }}</textarea><br>
+    <div class="max-w-7xl mx-auto mt-8 bg-yellow-300 p-8 rounded-[24px] shadow-md space-y-8">
+        {% if error_message %}
+            <p style="color: red;">{{ error_message }}</p>
+        {% endif %}
 
-        <label for="address">聚會地址：</label>
-        <input type="text" id="address" name="address" value="{{ activity.address }}" required><br>
+       
 
-        <label for="start_time">開始時間：</label>
-        <input type="datetime-local" id="start_time" name="start_time" value="{{ activity.start_time|date:"Y-m-d\TH:i" }}" required><br>
+        <!-- 表單區域開始 -->
+        <form method="POST" class="pt-8 ">
+            {% csrf_token %}
+            <div class="mb-4">
+                <label for="title" class="block text-gray-700">聚會標題：</label>
+                <input type="text" id="title" name="title" value="{{ activity.title }}" required class="w-full p-2 mt-2 border rounded">
+            </div>
 
-        <label for="duration">持續時間（小時）：</label>
-        <input type="number" id="duration" name="duration" value="{{ activity.duration }}" min="1" required><br>
+            <div class="mb-4">
+                <label for="description" class="block text-gray-700">聚會描述：</label>
+                <textarea id="description" name="description" class="w-full p-2 mt-2 border rounded">{{ activity.description }}</textarea>
+            </div>
 
-         <label class="block font-bold text-gray-800 mb-2">聚會類別：</label>
-        {{ form.category }}
-        {% for error in form.category.errors %}
-            <p style="color: red;">{{ error }}</p>
-        {% endfor %}
-        <br>
+            <div class="mb-4">
+                <label for="address" class="block text-gray-700">聚會地址：</label>
+                <input type="text" id="address" name="address" value="{{ activity.address }}" required class="w-full p-2 mt-2 border rounded">
+            </div>
+
+            <div class="mb-4">
+                <label for="start_time" class="block text-gray-700">開始時間：</label>
+                <input type="datetime-local" id="start_time" name="start_time" value="{{ activity.start_time|date:"Y-m-d\TH:i" }}" required class="w-full p-2 mt-2 border rounded">
+            </div>
+
+            <div class="mb-4">
+                <label for="duration" class="block text-gray-700">持續時間（小時）：</label>
+                <input type="number" id="duration" name="duration" value="{{ activity.duration }}" min="1" required class="w-full p-2 mt-2 border rounded">
+            </div>
+
+            <div class="mb-4">
+                <label class="block font-bold text-gray-800 mb-2">聚會類別：</label>
+                {{ form.category }}
+                {% for error in form.category.errors %}
+                    <p style="color: red;">{{ error }}</p>
+                {% endfor %}
+            </div>
+
+            <div class="mb-4">
+                <label for="max_participants" class="block text-gray-700">參加人數上限：</label>
+                <input type="number" id="max_participants" name="max_participants" value="{{ activity.max_participants }}" min="1" required class="w-full p-2 mt-2 border rounded">
+            </div>
+
+            <button type="submit" class="w-full py-2 rounded-full bg-moordule-pink text-white font-bold">更新聚會</button>
+        </form>
 
 
+    <h3 class="flex justify-center my-10 text-4xl">原卡牌資訊</h3>
+         <!-- 卡牌顯示 -->
+        <div class="flex flex-wrap justify-center gap-6 mx-2 pt-8">
+            <div class="w-full sm:w-1/2 md:w-1/3 lg:w-1/5 rounded-3xl overflow-hidden shadow-lg">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}" class="h-48 w-full object-cover" />
+                <div class="bg-moordule-pink p-4">
+                    <div class="flex justify-between items-center mb-2">
+                        <h3>{{ activity.title }}</h3>
+                        <div class="flex items-center gap-1">
+                            <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                                <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/>
+                            </svg>
+                            <span>已參加{{ activity.participants.count }} / {{ activity.max_participants }}人</span>
+                        </div>
+                    </div>
+                    <div class="flex justify-between gap-2 text-sm mb-2">
+                        <div class="flex">
+                            <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                                <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+                            </svg>
+                            <p>地點: {{ activity.address }}</p>
+                        </div>
+                        <p>時間: {{ activity.start_time|date:"Y-m-d H:i" }}</p>
+                    </div>
+                   
+                    <span class="text-lg font-medium">聚會內容：</span>
+                    <p class="text-sm mb-4 text-lg">{{ activity.description }}</p>
+                </div>
+            </div>
+        </div>
 
 
-        <label for="max_participants">參加人數上限：</label>
-        <input type="number" id="max_participants" name="max_participants" value="{{ activity.max_participants }}" min="1" required><br>
-
-        <button type="submit">更新聚會</button>
-
-    </form>
-</body>
-
+    </div>
+</div>
 {% endblock content %}

--- a/pages/templates/pages/index.html
+++ b/pages/templates/pages/index.html
@@ -157,9 +157,8 @@
           class="w-164 h-164 object-contain mt-40"
         />
       </div>
-      {% comment %}
-      <h1 class="text-3xl font-bold mb-2">MOORDULE 多揪</h1>
-      {% endcomment %}
+  
+
       <p class="text-gray-600 mb-4 text-xl">揪朋友 來多揪 越多朋友越好揪</p>
       <p class="text-gray-500 mb-4 text-lg">
         More friends you meet, the more life feels sweeet.
@@ -182,42 +181,35 @@
 
     <div id="drink" class="mx-20 pt-12">
       <div class="flex justify-center gap-12">
-        <!-- Card 1 -->
+        {% comment %} Card {% endcomment %}
         {% for activity in upcoming_activities %}
-        <div class="w-82 rounded-3xl overflow-hidden shadow-lg">
-          <img
-           img src="{{ activity.photo.url }}" alt="{{ activity.title }}"
-            class="h-48 w-full object-cover"
-          />
-          <div class="bg-moordule-yellow p-4">
-            <div class="flex justify-between items-center mb-2">
-              <h3 class="font-bold text-2xl">{{activity.title}}</h3>
-              <div class="flex items-center gap-1">
-                <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                  <path
-                    d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                  />
-                </svg>
-                <span>已參加{{ activity.participants.count }} / 最多{{ activity.max_participants }}人</span>
-              </div>
-            </div>
-            <div class="flex justify-between gap-2 text-sm mb-2">
-              <div class="flex">
-                <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
-                  <path
-                    fill-rule="evenodd"
-                    d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-                <span>{{ activity.address }}</span>
-              </div>
-              <span class="text-lg">{{ activity.start_time|date:"Y-m-d H:i" }}</span>
-            </div>
-            <span class="text-lg font-medium">聚會內容：</span>
-            <p class="text-sm mb-4 text-lg">
-             {{ activity.description }}                                                                          
-            </p>
+        
+                <div class="w-1/5 rounded-3xl overflow-hidden shadow-lg ">
+                <img src="{{ activity.photo.url }}" alt="{{ activity.title }}"  class="h-48 w-full object-cover" />
+                <div class="bg-moordule-yellow p-4  h-full">
+                  <div class="flex justify-between items-center mb-2">
+                    <h3>{{ activity.title }}</h3>
+                    <div class="flex items-center gap-1">
+                      <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/>
+                      </svg>
+                        <span>已參加{{ activity.participants.count }} / {{ activity.max_participants }}人</span>
+                    </div>
+                  </div>
+                  <div class="flex justify-between gap-2 text-sm mb-2">
+                    <div class="flex">
+                      <svg class="w-6 h-6" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+                      </svg>
+                      <p>地點: {{ activity.address }}</p>
+                    </div>
+                    <p>時間: {{ activity.start_time|date:"Y-m-d H:i" }}</p>
+                  </div>
+                  <span class="text-lg font-medium">聚會內容：</span>
+                  <p class="text-sm mb-4 text-lg">
+                    {{ activity.description }}
+                  </p>
+
             <a href="{% url 'activities:join' activity.id %}">
             <button class="w-full py-2 rounded-full bg-white  font-bold"
             >

--- a/pages/views.py
+++ b/pages/views.py
@@ -12,7 +12,7 @@ def index_view(request):
 
     upcoming_activities = Activity.objects.filter(
         start_time__gte=now, start_time__lte=tomorrow
-    ).order_by("start_time")
+    ).order_by("start_time")[:4]
 
     context = {
         "upcoming_activities": upcoming_activities,

--- a/users/templates/users/components/my_activities.html
+++ b/users/templates/users/components/my_activities.html
@@ -6,7 +6,7 @@
     <div class="container mx-auto mt-6 px-4">
      {% comment %}所有聚會 (已審核和未審核共用同一區塊) {% endcomment %}
 
-        <div class="max-w-7xl  mx-auto mt-8 bg-yellow-300 p-8 rounded-[24px]  shadow-md space-y-8">
+        <div class="max-w-7xl  mx-auto mt-8 bg-moordule-yellow  p-8 rounded-[24px]  shadow-md space-y-8">
 
     <div class="p-4 rounded-[24px] shadow-inner border-2 border-white">
      {% comment %} 
@@ -22,14 +22,14 @@
                     <div class="w-80 rounded-3xl overflow-hidden shadow-lg border border-white ">
                                 <img src="{{ activity.photo.url }}" alt="{{ activity.title }}"
                                     class="h-48 w-full object-cover">
-                                <div class="bg-white p-4">
+                                <div class="bg-white p-4 h-full">
                                     <div class="flex justify-between items-center mb-2">
                                         <h3 class="font-bold text-2xl">{{ activity.title }}</h3>
                                         <div class="flex items-center gap-1">
                                             <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
                                                 <path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" />
                                             </svg>
-                                            <span>{{ activity.participants_count }}</span>
+                                            <span>最多{{ activity.max_participants }}人</span>
                                         </div>
                                     </div>
                                     <div class="flex justify-between gap-2 text-sm mb-2">


### PR DESCRIPTION
#116 
- [ ] 聚會個類別頁面的假圖拔掉
- [ ] 修正卡牌因內容長短不同，而造成背景色跑版的狀況
- [ ] 修正首頁，今日聚會只出現“四個“最新聚會的卡牌
- [ ] 參加活動後的跳轉頁面路徑要加入#，才不會跑到最上面，修正提示
- [ ] 增加 更改與刪除頁面切版
- [ ] 按鈕綁上連結
- fix:更改頁面樣式

<img width="1710" alt="截圖 2025-01-10 下午6 25 42" src="https://github.com/user-attachments/assets/2f5f9a81-b1eb-4853-b69e-c3867a9b560f" />

<img width="1710" alt="截圖 2025-01-10 下午6 22 44" src="https://github.com/user-attachments/assets/ce3a96a8-f9b1-43bf-8618-b0a6c843b080" />


<img width="1710" alt="截圖 2025-01-10 晚上9 21 50" src="https://github.com/user-attachments/assets/ec3545c8-2805-45bc-b710-3c70e8ded737" />

<img width="1710" alt="截圖 2025-01-10 晚上9 18 42" src="https://github.com/user-attachments/assets/ab324cb1-af2b-499b-b470-3d4eb89b4969" />
