### PR TITLE
J-fix:show correct member plan, adjust layout

### DIFF
--- a/users/templates/users/components/wallet.html
+++ b/users/templates/users/components/wallet.html
@@ -4,7 +4,7 @@
   
     <div class="flex flex-col sm:flex-row items-center justify-center m-8 gap-4">
       <!-- 我的錢包 -->
-      <div class="basis-1/1 sm:basis-1/3 gap-4">
+      <div class="basis-1/2 sm:basis-1/3 gap-4">
         <div class="bg-white p-4 rounded-[24px] shadow-lg text-center">
           <h3 class="text-gray-700 mb-2 text-xl">我的錢包</h3>
           <div class="h-12 mx-auto mb-4 flex items-center justify-center">
@@ -18,12 +18,12 @@
             <span class="text-white-shadow text-lg">元</span>
           </div>
           <div class="text-center m-8 bg-white rounded-full">
-            {% if membership == "basic" %}
+            {% if membership == "Basic" %}
               <ul>
                 <li> 歡迎加入多揪</li>
                 <li> 請加值參加聚會</li>
               </ul>
-            {% elif membership == "silver" %}
+            {% elif membership == "Silver" %}
               <ul>
                 <li><span class="mr-2">✓</span> 參加聚會 $199/次</li>
                 <li><span class="mr-2">✓</span> 贈送 $50 聚會金</li>
@@ -55,11 +55,11 @@
       </div>
   
       <!-- 交易紀錄 -->
-      <div class="basis-1/1 sm:basis-2/3">
+      <div class="basis-1/2 sm:basis-2/3">
         <h2 class="text-center bg-white rounded-3xl m-8 text-gray-700 mb-2 text-xl">交易紀錄</h2>
         
         <div class="overflow-x-auto">
-          <table class="min-w-max table-auto bg-white rounded-3xl">
+          <table class="min-w-full table-auto bg-white rounded-3xl">
             <thead>
               <tr>
                 <th class="border border-gray-300 text-center p-2">日期</th>


### PR DESCRIPTION
#421 

- [ ] 修正原本 basic, silver會員無法正確顯示出會員方案
- [ ] 調整交易紀錄的樣式
<img width="877" alt="截圖 2025-01-17 下午2 11 38" src="https://github.com/user-attachments/assets/a9dac1ee-f587-43be-808b-13eef415ca61" />
